### PR TITLE
Fix MingGW-w64 compiler errors

### DIFF
--- a/include/EAStdC/EAStopwatch.h
+++ b/include/EAStdC/EAStopwatch.h
@@ -643,6 +643,11 @@ namespace StdC
 	// You can disable usage of QueryPerformanceCounter below by defining
 	// EASTDC_STOPWATCH_FORCE_CPU_CYCLE_USAGE as 1.
 	// hardcode prototype here so we don't pull in <windows.h>
+
+	#if !defined(_Out_)
+		#define _Out_
+	#endif
+
 	extern "C" __declspec(dllimport) int __stdcall QueryPerformanceCounter(_Out_ union _LARGE_INTEGER *lpPerformanceCount);
 
 	inline uint64_t EA::StdC::Stopwatch::GetStopwatchCycle()


### PR DESCRIPTION
The current headers don't pull in `_Out_`, so I added a check to define it.  
I cross checked with MSVC headers, and it doesn't get defined to anything.