### PR TITLE
Fix CMake build on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ target_include_directories(EAStdC PRIVATE ../EABase/include/Common)
 #-------------------------------------------------------------------------------------------
 # Dependencies
 #-------------------------------------------------------------------------------------------
-target_link_libraries(EAStdC EABase)
 target_link_libraries(EAStdC EAAssert)
 target_link_libraries(EAStdC EAThread)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_definitions(-D_CHAR16T)
 # Include directories
 #-------------------------------------------------------------------------------------------
 target_include_directories(EAStdC PUBLIC include)
+target_include_directories(EAStdC PRIVATE ../EABase/include/Common)
 
 #-------------------------------------------------------------------------------------------
 # Dependencies

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,7 +49,7 @@ add_subdirectory(packages/EASTL)
 add_subdirectory(packages/EATest)
 add_subdirectory(packages/EAThread)
 
-target_link_libraries(EAStdCTest EABase)
+)
 target_link_libraries(EAStdCTest EAAssert)
 target_link_libraries(EAStdCTest EAMain)
 target_link_libraries(EAStdCTest EASTL)


### PR DESCRIPTION
Change EABase from link to include - the libraries won't build otherwise on Ubuntu.
I'm guessing that in the past EABase was a binary library to link against, and was changed to header only - but I didn't chase its history.