### PR TITLE
Change .gitmodules to use https links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,18 @@
 [submodule "test/packages/EAMain"]
 	path = test/packages/EAMain
-	url = git@github.com:electronicarts/EAMain.git
+	url = https://github.com/electronicarts/EAMain.git
 [submodule "test/packages/EATest"]
 	path = test/packages/EATest
-	url = git@github.com:electronicarts/EATest.git
+	url = https://github.com/electronicarts/EATest.git
 [submodule "test/packages/EAAssert"]
 	path = test/packages/EAAssert
-	url = git@github.com:electronicarts/EAAssert.git
+	url = https://github.com/electronicarts/EAAssert.git
 [submodule "test/packages/EAThread"]
 	path = test/packages/EAThread
-	url = git@github.com:electronicarts/EAThread.git
+	url = https://github.com/electronicarts/EAThread.git
 [submodule "test/packages/EASTL"]
 	path = test/packages/EASTL
-	url = git@github.com:electronicarts/EASTL.git
+	url = https://github.com/electronicarts/EASTL.git
 [submodule "test/packages/EABase"]
 	path = test/packages/EABase
-	url = git@github.com:electronicarts/EABase.git
+	url = https://github.com/electronicarts/EABase.git


### PR DESCRIPTION
Use https links for submodules rather than requiring a public key for git@github.com.

I had a problem cloning this repo because it required a public key.  This will make it more accessible to clone.  I'd suggest doing the same for the other repositories as well (EAMain, EATest, EAThread, EAAssert, EASTL and EABase.)